### PR TITLE
catkin: 0.7.4-4 in 'minimalist/distribution.yaml' [bloom]

### DIFF
--- a/minimalist/distribution.yaml
+++ b/minimalist/distribution.yaml
@@ -3,6 +3,8 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
+  arch:
+  - current
   debian:
   - jessie
   fedora:
@@ -11,8 +13,12 @@ release_platforms:
   ubuntu:
   - wily
   - xenial
-  arch:
-  - current
 repositories:
+  catkin:
+    release:
+      tags:
+        release: release/minimalist/{package}/{version}
+      url: https://github.com/gdlg/catkin-release.git
+      version: 0.7.4-4
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.4-4`:
- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/gdlg/catkin-release.git
- distro file: `minimalist/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## catkin

```
* fix regression in logic to select make / ninja for CMake packages from 0.7.2 (#826 <https://github.com/ros/catkin/issues/826>)
```
