### PR TITLE
cmake_modules: 0.4.0-0 in 'minimalist/distribution.yaml' [bloom]

### DIFF
--- a/minimalist/distribution.yaml
+++ b/minimalist/distribution.yaml
@@ -20,5 +20,11 @@ repositories:
         release: release/minimalist/{package}/{version}
       url: https://github.com/gdlg/catkin-release.git
       version: 0.7.4-4
+  cmake_modules:
+    release:
+      tags:
+        release: release/minimalist/{package}/{version}
+      url: https://github.com/gdlg/cmake_modules-release.git
+      version: 0.4.0-0
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.4.0-0`:
- upstream repository: https://github.com/ros/cmake_modules.git
- release repository: https://github.com/gdlg/cmake_modules-release.git
- distro file: `minimalist/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## cmake_modules

```
* The Eigen module provided by this package has been deprecated.
  There is now a CMake warning to encourage people to use the Module provided by Eigen instead.
* Contributors: William Woodall
```
