### PR TITLE
genmsg: 0.5.8-0 in 'minimalist/distribution.yaml' [bloom]

### DIFF
--- a/minimalist/distribution.yaml
+++ b/minimalist/distribution.yaml
@@ -26,5 +26,11 @@ repositories:
         release: release/minimalist/{package}/{version}
       url: https://github.com/gdlg/cmake_modules-release.git
       version: 0.4.0-0
+  genmsg:
+    release:
+      tags:
+        release: release/minimalist/{package}/{version}
+      url: https://github.com/gdlg/genmsg-release.git
+      version: 0.5.8-0
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.8-0`:
- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/gdlg/genmsg-release.git
- distro file: `minimalist/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## genmsg

```
* check target across package for existance (#65 <https://github.com/ros/genmsg/issues/65>)
* do not hardcode errno values (#64 <https://github.com/ros/genmsg/issues/64>)
```
