### PR TITLE
genpy: 0.6.2-0 in 'minimalist/distribution.yaml' [bloom]

### DIFF
--- a/minimalist/distribution.yaml
+++ b/minimalist/distribution.yaml
@@ -32,5 +32,11 @@ repositories:
         release: release/minimalist/{package}/{version}
       url: https://github.com/gdlg/genmsg-release.git
       version: 0.5.8-0
+  genpy:
+    release:
+      tags:
+        release: release/minimalist/{package}/{version}
+      url: https://github.com/gdlg/genpy-release.git
+      version: 0.6.2-0
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.6.2-0`:
- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/gdlg/genpy-release.git
- distro file: `minimalist/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## genpy

```
* fix regression regarding lazy init introduced in 0.6.1 (#67 <https://github.com/ros/genpy/issues/67>)
```
