### PR TITLE
gencpp: 0.5.5-0 in 'minimalist/distribution.yaml' [bloom]

### DIFF
--- a/minimalist/distribution.yaml
+++ b/minimalist/distribution.yaml
@@ -26,6 +26,12 @@ repositories:
         release: release/minimalist/{package}/{version}
       url: https://github.com/gdlg/cmake_modules-release.git
       version: 0.4.0-0
+  gencpp:
+    release:
+      tags:
+        release: release/minimalist/{package}/{version}
+      url: https://github.com/gdlg/gencpp-release.git
+      version: 0.5.5-0
   genmsg:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp` to `0.5.5-0`:
- upstream repository: git@github.com:ros/gencpp.git
- release repository: https://github.com/gdlg/gencpp-release.git
- distro file: `minimalist/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## gencpp

```
* fix extra semicolon warning (#26 <https://github.com/ros/gencpp/issues/26>)
```
