### PR TITLE
genlisp: 0.4.16-0 in 'minimalist/distribution.yaml' [bloom]

### DIFF
--- a/minimalist/distribution.yaml
+++ b/minimalist/distribution.yaml
@@ -26,6 +26,12 @@ repositories:
         release: release/minimalist/{package}/{version}
       url: https://github.com/gdlg/cmake_modules-release.git
       version: 0.4.0-0
+  genlisp:
+    release:
+      tags:
+        release: release/minimalist/{package}/{version}
+      url: https://github.com/gdlg/genlisp-release.git
+      version: 0.4.16-0
   genmsg:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `genlisp` to `0.4.16-0`:
- upstream repository: git@github.com:ros/genlisp.git
- release repository: https://github.com/gdlg/genlisp-release.git
- distro file: `minimalist/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
