### PR TITLE
genlisp: 0.4.16-0 in 'minimalist/distribution.yaml' [bloom]

### DIFF
--- a/minimalist/distribution.yaml
+++ b/minimalist/distribution.yaml
@@ -32,6 +32,12 @@ repositories:
         release: release/minimalist/{package}/{version}
       url: https://github.com/gdlg/geneus-release.git
       version: 2.2.5-0
+  genlisp:
+    release:
+      tags:
+        release: release/minimalist/{package}/{version}
+      url: https://github.com/gdlg/genlisp-release.git
+      version: 0.4.16-0
   genmsg:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `genlisp` to `0.4.16-0`:
- upstream repository: git@github.com:ros/genlisp.git
- release repository: https://github.com/gdlg/genlisp-release.git
- distro file: `minimalist/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
