### PR TITLE
gennodejs: 1.0.3-0 in 'minimalist/distribution.yaml' [bloom]

### DIFF
--- a/minimalist/distribution.yaml
+++ b/minimalist/distribution.yaml
@@ -44,6 +44,12 @@ repositories:
         release: release/minimalist/{package}/{version}
       url: https://github.com/gdlg/genmsg-release.git
       version: 0.5.8-0
+  gennodejs:
+    release:
+      tags:
+        release: release/minimalist/{package}/{version}
+      url: https://github.com/gdlg/gennodejs-release.git
+      version: 1.0.3-0
   genpy:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `gennodejs` to `1.0.3-0`:
- upstream repository: https://github.com/RethinkRobotics-opensource/gennodejs.git
- release repository: https://github.com/gdlg/gennodejs-release.git
- distro file: `minimalist/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## gennodejs

```
* Removed extraneous base file installs
* Revert install space fix that re-used base js files per package
* Added install space fix that copies base js files per package
* Contributors: Ian McMahon, Rob Linsalata
```
