### PR TITLE
message_generation: 0.4.0-0 in 'minimalist/distribution.yaml' [bloom]

### DIFF
--- a/minimalist/distribution.yaml
+++ b/minimalist/distribution.yaml
@@ -62,5 +62,11 @@ repositories:
         release: release/minimalist/{package}/{version}
       url: https://github.com/gdlg/genpy-release.git
       version: 0.6.2-0
+  message_generation:
+    release:
+      tags:
+        release: release/minimalist/{package}/{version}
+      url: https://github.com/gdlg/message_generation-release.git
+      version: 0.4.0-0
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `message_generation` to `0.4.0-0`:
- upstream repository: https://github.com/ros/message_generation.git
- release repository: https://github.com/gdlg/message_generation-release.git
- distro file: `minimalist/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
