### PR TITLE
roscpp_core-release: 0.6.1-0 in 'minimalist/distribution.yaml' [bloom]

### DIFF
--- a/minimalist/distribution.yaml
+++ b/minimalist/distribution.yaml
@@ -68,5 +68,17 @@ repositories:
         release: release/minimalist/{package}/{version}
       url: https://github.com/gdlg/message_generation-release.git
       version: 0.4.0-0
+  roscpp_core-release:
+    release:
+      packages:
+      - cpp_common
+      - roscpp_core
+      - roscpp_serialization
+      - roscpp_traits
+      - rostime
+      tags:
+        release: release/minimalist/{package}/{version}
+      url: https://github.com/gdlg/roscpp_core-release.git
+      version: 0.6.1-0
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core-release` to `0.6.1-0`:
- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/gdlg/roscpp_core-release.git
- distro file: `minimalist/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
## cpp_common
- No changes
## roscpp_serialization

```
* fix warning about unused parameter (#51 <https://github.com/ros/roscpp_core/pull/51>)
```
## roscpp_traits
- No changes
## rostime

```
* fix rounding errors leading to invalid stored data in ros::TimeBase (#48 <https://github.com/ros/roscpp_core/issues/48>)
```
