### PR TITLE
catkin: 0.7.4-5 in 'minimalist/distribution.yaml' [bloom]

### DIFF
--- a/minimalist/distribution.yaml
+++ b/minimalist/distribution.yaml
@@ -19,7 +19,7 @@ repositories:
       tags:
         release: release/minimalist/{package}/{version}
       url: https://github.com/gdlg/catkin-release.git
-      version: 0.7.4-4
+      version: 0.7.4-5
   cmake_modules:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.4-5`:
- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/gdlg/catkin-release.git
- distro file: `minimalist/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `0.7.4-4`
## catkin

```
* fix regression in logic to select make / ninja for CMake packages from 0.7.2 (#826 <https://github.com/ros/catkin/issues/826>)
```
