### PR TITLE
message_runtime: 0.4.12-0 in 'minimalist/distribution.yaml' [bloom]

### DIFF
--- a/minimalist/distribution.yaml
+++ b/minimalist/distribution.yaml
@@ -68,6 +68,12 @@ repositories:
         release: release/minimalist/{package}/{version}
       url: https://github.com/gdlg/message_generation-release.git
       version: 0.4.0-0
+  message_runtime:
+    release:
+      tags:
+        release: release/minimalist/{package}/{version}
+      url: https://github.com/gdlg/message_runtime-release.git
+      version: 0.4.12-0
   roscpp_core-release:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `message_runtime` to `0.4.12-0`:
- upstream repository: https://github.com/ros/message_runtime.git
- release repository: https://github.com/gdlg/message_runtime-release.git
- distro file: `minimalist/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `null`
